### PR TITLE
Fix warning with -DSKIP_optix=true

### DIFF
--- a/ubuntu/debian/rules
+++ b/ubuntu/debian/rules
@@ -18,6 +18,7 @@ endif
 
 override_dh_auto_configure:
 	dh_auto_configure -- \
+	    -DSKIP_optix=true \
 	    -DCMAKE_BUILD_TYPE=RelWithDebInfo $(EXTRA_CMAKE_FLAGS)
 
 override_dh_install:


### PR DESCRIPTION
Nightly builds have been unstable for a long time. I think it's caused by a cmake error:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign-rendering7-debbuilder&build=256)](https://build.osrfoundation.org/view/ign-garden/job/ign-rendering7-debbuilder/256/) https://build.osrfoundation.org/view/ign-garden/job/ign-rendering7-debbuilder/256/

~~~
-- Looking for OptiX - not found

CMake Warning at /usr/share/cmake/ignition-cmake2/cmake2/IgnConfigureBuild.cmake:55 (message):
   CONFIGURATION WARNINGS:
   -- Skipping component [optix]: Missing dependency [OptiX].
      ^~~~~ Set SKIP_optix=true in cmake to suppress this warning.
   
Call Stack (most recent call first):
  CMakeLists.txt:172 (ign_configure_build)


-- 
~~~

Testing with this branch:

* ~~[![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign-rendering7-debbuilder&build=257)](https://build.osrfoundation.org/view/ign-garden/job/ign-rendering7-debbuilder/257/) https://build.osrfoundation.org/view/ign-garden/job/ign-rendering7-debbuilder/257/~~
* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign-rendering7-debbuilder&build=258)](https://build.osrfoundation.org/view/ign-garden/job/ign-rendering7-debbuilder/258/) https://build.osrfoundation.org/view/ign-garden/job/ign-rendering7-debbuilder/258/