### PR TITLE
Fix arm64 build on Focal: update to GZ the CMake variable

### DIFF
--- a/ubuntu/debian/rules
+++ b/ubuntu/debian/rules
@@ -3,7 +3,7 @@
 
 EXTRA_CMAKE_FLAGS =
 ifneq (,$(filter $(DEB_HOST_ARCH_CPU), arm64 arm))
-    EXTRA_CMAKE_FLAGS = -DIGN_ADD_fPIC_TO_LIBRARIES=True
+    EXTRA_CMAKE_FLAGS = -DGZ_ADD_fPIC_TO_LIBRARIES=True
 endif
 
 .PHONY: override_dh_auto_configure \


### PR DESCRIPTION
Before: it was failing to build with fPIC problems https://build.osrfoundation.org/view/ign-garden/job/gz-rendering7-debbuilder/681/consoleFull#9963089026ea37b8d-a6d4-40ae-8431-d90c018842af

With this branch: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz-rendering7-debbuilder&build=692)](https://build.osrfoundation.org/view/ign-garden/job/gz-rendering7-debbuilder/692/)

